### PR TITLE
@argumentTransform optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ enum ParamTransformType{
 参数解释：
 - argumentName：该指令进行转换的参数名称；
 - operateType：操作类型，包括参数整体转换MAP、列表参数过滤FILTER、列表参数元素转换LIST_MAP三种；
-- expression：计算新值、或者对参数进行过滤的表达式；
+- expression：计算新值、或者对参数进行过滤的表达式，表达式参数为请求变量和source，如果存在同名key则source覆盖请求变量；
 - dependencySources：表达式依赖的source，source如果和参数变量同名、则会覆盖后者。
 
 对字段参数进行转换、过滤，具体操作有如下三种：

--- a/src/main/java/calculator/engine/ExecutionEngine.java
+++ b/src/main/java/calculator/engine/ExecutionEngine.java
@@ -47,7 +47,6 @@ import graphql.schema.DataFetchingEnvironmentImpl;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -496,7 +495,7 @@ public class ExecutionEngine extends SimpleInstrumentation {
             }
 
             // new Map, do not alter original Map info.
-            HashMap<String, Object> expEnv = new HashMap<>();
+            Map<String, Object> expEnv = new LinkedHashMap<>();
             Object sourceInfo = getScriptEnv(environment.getSource());
             if (sourceInfo != null) {
                 expEnv.putAll((Map) sourceInfo);
@@ -545,14 +544,14 @@ public class ExecutionEngine extends SimpleInstrumentation {
                 }
 
                 argument = argument.stream().filter(ele -> {
-                            HashMap<String, Object> env = new HashMap<>(environment.getArguments());
-                            env.put("ele", ele);
-                            env.putAll(sourceEnv);
-                            return (Boolean) scriptEvaluator.evaluate(expression, env);
+                            Map<String, Object> filterEnv = new LinkedHashMap<>(environment.getVariables());
+                            filterEnv.put("ele", ele);
+                            filterEnv.putAll(sourceEnv);
+                            return (Boolean) scriptEvaluator.evaluate(expression, filterEnv);
                         }
                 ).collect(toList());
 
-                Map<String, Object> newArguments = new HashMap<>(environment.getArguments());
+                Map<String, Object> newArguments = new LinkedHashMap<>(environment.getArguments());
                 newArguments.put(argumentName, argument);
                 DataFetchingEnvironment newEnvironment = DataFetchingEnvironmentImpl
                         .newDataFetchingEnvironment(environment).arguments(newArguments).build();
@@ -571,13 +570,13 @@ public class ExecutionEngine extends SimpleInstrumentation {
                 }
 
                 argument = argument.stream().map(ele -> {
-                    Map<String, Object> transformEnv = new HashMap<>(environment.getArguments());
+                    Map<String, Object> transformEnv = new LinkedHashMap<>(environment.getVariables());
                     transformEnv.put("ele", ele);
                     transformEnv.putAll(sourceEnv);
                     return scriptEvaluator.evaluate(expression, transformEnv);
                 }).collect(toList());
 
-                Map<String, Object> newArguments = new HashMap<>(environment.getArguments());
+                Map<String, Object> newArguments = new LinkedHashMap<>(environment.getArguments());
                 newArguments.put(argumentName, argument);
                 DataFetchingEnvironment newEnvironment = DataFetchingEnvironmentImpl
                         .newDataFetchingEnvironment(environment).arguments(newArguments).build();
@@ -592,11 +591,11 @@ public class ExecutionEngine extends SimpleInstrumentation {
             // map argument by expression
             if (Objects.equals(operateType, Directives.ParamTransformType.MAP.name())) {
 
-                Map<String, Object> transformEnv = new HashMap<>(environment.getArguments());
+                Map<String, Object> transformEnv = new LinkedHashMap<>(environment.getVariables());
                 transformEnv.putAll(sourceEnv);
                 Object newParam = scriptEvaluator.evaluate(expression, transformEnv);
 
-                Map<String, Object> newArguments = new HashMap<>(environment.getArguments());
+                Map<String, Object> newArguments = new LinkedHashMap<>(environment.getArguments());
                 newArguments.put(argumentName, newParam);
 
                 DataFetchingEnvironment newEnvironment = DataFetchingEnvironmentImpl

--- a/src/main/java/calculator/engine/metadata/Directives.java
+++ b/src/main/java/calculator/engine/metadata/Directives.java
@@ -208,7 +208,7 @@ public class Directives {
                             .description("filter the argument element by expression.").build()
             ).build();
 
-    // directive @argumentTransform(argument:String!, operaType:ParamTransformType, expression:String, dependencySource:String) on FIELD
+    // directive @argumentTransform(argument:String!, operaType:ParamTransformType, expression:String, dependencySource:String) repeatable on FIELD
     public final static GraphQLDirective ARGUMENT_TRANSFORM = GraphQLDirective.newDirective()
             .name("argumentTransform")
             .description("transform the argument by expression.")

--- a/src/test/resources/examples.graphql
+++ b/src/test/resources/examples.graphql
@@ -1,5 +1,5 @@
-# 指令定义
 
+# 指令定义
 directive @fetchSource(name: String!, sourceConvert:String) on FIELD
 directive @skipBy(predicate: String!, dependencySources: [String!]) on FIELD
 directive @includeBy(predicate: String!, dependencySources:[String!]) on FIELD
@@ -9,12 +9,55 @@ directive @sort(key: String!,reversed: Boolean = false) on FIELD
 directive @sortBy(comparator: String!, reversed: Boolean = false) on FIELD
 directive @map(mapper:String!, dependencySources:[String!]) on FIELD
 directive @argumentTransform(argumentName:String!, operateType:ParamTransformType, expression:String, dependencySources:[String!]) on FIELD
+
+#directive @argumentTransform(argument:String!, operaType:ParamTransformType, expression:String, dependencySource:String) repeatable on FIELD
 enum ParamTransformType{
     MAP
     FILTER
     LIST_MAP
 }
 
+
+query parseArgumentFromVariableSimpleCase_01($userIds:[Int]){
+    consumer{
+        userInfoList(userIds: $userIds){
+            userId
+            age
+            name
+        }
+
+        # get argument from variable, 'testUserInfoList' haven't use any variable
+        testUserInfoList: userInfoList(userIds: 1)
+        @argumentTransform(argumentName: "userIds",operateType: MAP,expression: "userIds")
+        {
+            userId
+            age
+            name
+        }
+    }
+}
+
+
+#
+# 假设存在如下查询：刚开始只查询了 someInfo 字段，后续查询commodity字段的时候，
+#               希望从之前的请求变量userIdAnditemIdPair解析参数，而非调用方在硬编码添加参数
+#
+#query parseArgumentFromVariable_case01($userIdAnditemIdPair:Any){
+#
+#    someInfo: variableBlackhole(anyArgument: $userIdAnditemIdPair){
+#        ignored
+#    }
+#
+#    commodity{
+#        itemList(itemIds: 1)
+#        @argumentTransform(argumentName: "itemIds",operateType: MAP,expression: "mapValues(userIdAnditemIdPair)")
+#        {
+#            itemId
+#            name
+#            salePrice
+#        }
+#    }
+#}
 
 query queryMoreDetail_case01($userId:Int,$clientVersion:String){
     consumer{
@@ -217,9 +260,9 @@ query sortCase_01{
 # 参数拼接
 query userNewInfo($userId: Int){
     consumer{
-        isNewUser(redisKey: "fashion:shoes:",userId: $userId)
+        isNewUser(redisKey: "",userId: $userId)
         # 将参数拼接为 redis 的key，fashion:shoes:{userId}
-        @argumentTransform(argumentName: "redisKey",operateType: MAP ,expression: "concat(redisKey,userId)")
+        @argumentTransform(argumentName: "redisKey",operateType: MAP ,expression: "'fashion:shoes:' + str(userId)")
         {
             userId
             isNewUser

--- a/src/test/resources/schema.graphql
+++ b/src/test/resources/schema.graphql
@@ -1,4 +1,6 @@
-# https://www.zhihu.com/question/26679255/answer/1187193899
+## like Any in protobuf
+#scalar Any
+
 type Query {
     # c端 用户
     consumer: Consumer
@@ -16,6 +18,8 @@ type Query {
     # management: Management
 
     toolInfo: ToolInfo
+
+#    variableBlackhole(anyArgument: Any, anyArrayArgument: [Any]): Blackhole
 }
 
 
@@ -118,4 +122,9 @@ type ToolInfo{
     # 用户进行ab实验 abKey 时命中的实验落点
     abInfo(userId: Int, abKey: String): Int
 }
+
+
+#type Blackhole {
+#    ignored: String
+#}
 


### PR DESCRIPTION
`@argumentTransform` 表达式的参数从 **字段参数➕source** 改为 **请求变量+source**，因为字段变量参数是请求变量的子集，而且存在需要从请求变量中解析出字段参数的情况。

假设使用变量 userIdAndItemIdMap 获取某一字段信息：
```graphql
scalar Map

query demoQuery($userIdAndItemIdMap: Map){
        commonInfo(userIdAndItemIdPair:$userIdAndItemIdMap){
                 ... someFields
        }
}
```

后续需要添加用户信息的查询，并且字段参数从`$userIdAndItemIdMap` 解析：
```graphql

query demoQuery($userIdAndItemIdMap: Map){
        commonInfo(userIdAndItemIdPair:$userIdAndItemIdMap){
                 ... someFields
        }

        userInfoList(userIds: 1)
        @argumentTransform(argumentName: "userIds",operateType: MAP, expression: "mapKeys(userIdAndItemIdMap)")
        {
            userId
            age
            name
        }
}
```
